### PR TITLE
Accommodate building packed source trees

### DIFF
--- a/python-common.mk
+++ b/python-common.mk
@@ -1,3 +1,5 @@
+RPM_SPEC      := python-$(NAME).spec
+
 test_dependencies:
 	test_deps="$(TEST_DEPS)";                               \
 	if rpm --version && yum --version &&                    \

--- a/python-localsrc.mk
+++ b/python-localsrc.mk
@@ -1,6 +1,6 @@
 include include/git-versioning.mk
-include include/rpm-common.mk
 include include/python-common.mk
+include include/rpm-common.mk
 include include/copr.mk
 
 %.egg-info/SOURCES.txt:

--- a/python-pypi.mk
+++ b/python-pypi.mk
@@ -1,6 +1,6 @@
 BUILD_METHOD := PyPI
-include include/rpm-common.mk
 include include/python-common.mk
+include include/rpm-common.mk
 include include/copr.mk
 
 # don't rebuild if tracked by git since this has to be manually

--- a/rpm-common.mk
+++ b/rpm-common.mk
@@ -1,4 +1,4 @@
-RPM_SPEC      := python-$(NAME).spec
+RPM_SPEC      ?= $(NAME).spec
 
 ifndef DIST_VERSION
 DIST_VERSION	     := $(PACKAGE_VERSION)
@@ -17,9 +17,11 @@ TARGET_RPMS   := $(addprefix _topdir/RPMS/noarch/python-,  \
                    $(addsuffix -$(PACKAGE_VRD).noarch.rpm, \
                      $(ALL_PKGS)))
 
-RPM_SOURCES   := $(shell spectool --define version\ $(PACKAGE_VERSION) \
-		                  $(RPM_DIST_VERSION_ARG)              \
-		                  -l $(RPM_SPEC) | sed -e 's/.*\///')
+RPM_SOURCES   := $(shell spectool --define version\ $(PACKAGE_VERSION)   \
+		                  $(RPM_DIST_VERSION_ARG)                \
+		                  --define "epel 1"                      \
+		                  -l $(RPM_SPEC) |                       \
+				  sed -e 's/^[^:]*:  *//' -e 's/.*\///')
 
 MODULE_SUBDIR ?= $(subst -,_,$(NAME))
 
@@ -32,6 +34,7 @@ RPMBUILD_ARGS += $(RPM_DIST_VERSION_ARG)                       \
 		 --define "_topdir $$(pwd)/_topdir"            \
 		 --define "version $(PACKAGE_VERSION)"         \
 		 --define "package_release $(PACKAGE_RELEASE)" \
+		 --define "epel 1"                             \
 		 --define "%dist $(RPM_DIST)"
 
 TARGET_SRPM   := _topdir/SRPMS/$(shell rpm $(RPMBUILD_ARGS) -q             \
@@ -65,6 +68,7 @@ _topdir/SOURCES/%: %
 
 $(RPM_SOURCES):
 	if ! spectool $(RPM_DIST_VERSION_ARG)                  \
+		   --define "epel 1"                           \
 		   -g $(RPM_SPEC); then                        \
 	    echo "Failed to fetch $@.";                        \
 	    exit 1;                                            \

--- a/rpm.mk
+++ b/rpm.mk
@@ -1,0 +1,21 @@
+include include/rpm-common.mk
+
+VERSION_RELEASE := $(shell repoquery -q --qf "%{version}-%{release}" $(NAME) | sed -e 's/.el7//g')
+SRPM            := $(NAME)-$(VERSION_RELEASE).el7.src.rpm
+
+$(SRPM):
+	yumdownloader --source $(NAME)
+
+unpack: $(SRPM)
+	#if [ -d old ]; then                          \
+	#    echo "directory old already exists."     \
+	#         "please clean it up and try again"; \
+	#    exit 1;                                  \
+	#fi
+	#mkdir old
+	#mv $$(ls | egrep -v -e ^old$$ -e ^Makefile$$) old
+	rpm2cpio < $(SRPM) | cpio -iu
+
+download: $(SRPM)
+
+.PHONY: unpack download


### PR DESCRIPTION
Move python- prefixing of SPEC into python-common.mk and make
SPEC more generic for non-python packages.

Add epel macro to standard definitions.

Allow for non URL specified source in the specfile.

Add rpm.mk for building packed RPM sources.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>