### PR TITLE
Fix bug in commit-msg hook

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,4 +1,18 @@
 #!/bin/bash
 
 SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
-grep -qs "^$SOB" "$1" || echo "$SOB" >> "$1"
+if ! grep -qs "^$SOB" "$1"; then
+    mv "$1"{,.tmp}
+    trap 'rm $1.tmp' EXIT
+    added=false
+    while read -r line; do
+        if ! $added && [[ $line == \#* ]]; then
+            echo -e "\n$SOB"
+            added=true
+        fi
+        echo "$line"
+    done < "$1".tmp > "$1"
+    if ! $added; then
+        echo -e "\n$SOB" >> "$1"
+    fi
+fi


### PR DESCRIPTION
There was a bug where the Signed-off-by was always being added to the
end of the file even beyond the "Everything below will be removed."
marker.

Now add before the first comment line or at the end of the file if no
comment lines are present.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>