### PR TITLE
Remove -t flag when starting docker in travis

### DIFF
--- a/travis/run_in_centos7_docker.sh
+++ b/travis/run_in_centos7_docker.sh
@@ -7,10 +7,10 @@ MAPPED_DIR="${MAPPED_DIR:-/build}"
 env > travis_env
 
 # Run tests in Container
-docker run --privileged -d -ti -e "container=docker"  -v /sys/fs/cgroup:/sys/fs/cgroup -v "$(pwd)":"$MAPPED_DIR":rw centos:centos7 /usr/sbin/init
+docker run --privileged -d -i -e "container=docker"  -v /sys/fs/cgroup:/sys/fs/cgroup -v "$(pwd)":"$MAPPED_DIR":rw centos:centos7 /usr/sbin/init
 DOCKER_CONTAINER_ID=$(docker ps | grep centos | awk '{print $1}')
 docker logs "$DOCKER_CONTAINER_ID"
-docker exec -ti "$DOCKER_CONTAINER_ID" /bin/bash -xec "cd $MAPPED_DIR; $1"
+docker exec -i "$DOCKER_CONTAINER_ID" /bin/bash -xec "cd $MAPPED_DIR; $1"
 docker ps -a
 docker stop "$DOCKER_CONTAINER_ID"
 docker rm -v "$DOCKER_CONTAINER_ID"


### PR DESCRIPTION
Remove -t flag when starting docker in travis, it is not necessary and was causing issues.