### PR TITLE
Add support for building other modules from spec

### DIFF
--- a/copr.mk
+++ b/copr.mk
@@ -31,6 +31,8 @@ copr_build iml_copr_build: $(PREREQ)
 	#copr-cli buildpypi --packagename $(NAME)
 	#$(COPR_OWNER)/$(COPR_PROJECT)
 	copr-cli $(COPR_CONFIG) build $(OWNER_PROJECT) $^
+else ifeq ($(BUILD_METHOD),Registry)
+	copr-cli $(COPR_CONFIG) build $(OWNER_PROJECT) $^
 else
 copr_build iml_copr_build: $(RPM_SPEC)
 	copr-cli $(COPR_CONFIG) buildmock $(OWNER_PROJECT)       \

--- a/copr.mk
+++ b/copr.mk
@@ -32,6 +32,7 @@ copr_build iml_copr_build: $(PREREQ)
 	#$(COPR_OWNER)/$(COPR_PROJECT)
 	copr-cli $(COPR_CONFIG) build $(OWNER_PROJECT) $^
 else ifeq ($(BUILD_METHOD),Registry)
+copr_build iml_copr_build: $(PREREQ)
 	copr-cli $(COPR_CONFIG) build $(OWNER_PROJECT) $^
 else
 copr_build iml_copr_build: $(RPM_SPEC)


### PR DESCRIPTION
Fixes #9.

Add support for building other module
types from spec.

We do this by adding a BUILD_METHOD = "Registry"
to the project makefile.

Signed-off-by: Joe Grund <joe.grund@intel.com>