### PR TITLE
Move spectool fetching to rpm.mk and python-pypi.mk

### DIFF
--- a/rpm-common.mk
+++ b/rpm-common.mk
@@ -33,7 +33,7 @@ COMMON_RPMBUILD_ARGS += $(RPM_DIST_VERSION_ARG)                       \
 
 RPMBUILD_ARGS += $(COMMON_RPMBUILD_ARGS) --define "_topdir $$(pwd)/_topdir" 
 
-TARGET_SRPM   := _topdir/SRPMS/$(shell set -x; rpm $(RPMBUILD_ARGS) -q             \
+TARGET_SRPM   := _topdir/SRPMS/$(shell rpm $(RPMBUILD_ARGS) -q             \
 				 --qf %{name}-%{version}-%{release}\\n     \
 				 --specfile $(RPM_SPEC) | head -1).src.rpm
 
@@ -61,14 +61,6 @@ _topdir/SPECS/$(RPM_SPEC): $(RPM_SPEC)
 _topdir/SOURCES/%: %
 	mkdir -p _topdir/SOURCES
 	cp $< $@
-
-$(RPM_SOURCES):
-	if ! spectool $(RPM_DIST_VERSION_ARG)                  \
-		   --define "epel 1"                           \
-		   -g $(RPM_SPEC); then                        \
-	    echo "Failed to fetch $@.";                        \
-	    exit 1;                                            \
-	fi
 
 srpm: $(TARGET_SRPM)
 

--- a/rpm.mk
+++ b/rpm.mk
@@ -19,4 +19,15 @@ unpack: $(SRPM)
 
 download: $(SRPM)
 
-.PHONY: unpack download
+$(RPM_SOURCES):
+	if ! spectool $(RPM_DIST_VERSION_ARG)                  \
+		   --define "epel 1"                           \
+		   -g $(RPM_SPEC); then                        \
+	    echo "Failed to fetch $@.";                        \
+	    exit 1;                                            \
+	fi
+
+install_build_deps:
+	echo "Nothing to do"
+
+.PHONY: unpack download install_build_deps


### PR DESCRIPTION
Since it's really only applicable to rebuilding pre-existing
RPMs.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>