### PR TITLE
Move MODULE_SUBDIR; always make specfile

### DIFF
--- a/git-versioning.mk
+++ b/git-versioning.mk
@@ -47,6 +47,8 @@ else
 	BUILD_NUMBER := $(JENKINS_BUILD_TAG)
 endif
 
+MODULE_SUBDIR ?= $(subst -,_,$(NAME))
+
 # only overwrite scm_version.py if we have info from git
 ifneq ($(strip $(PACKAGE_VERSION)),)
 $(shell { echo 'VERSION = "$(VERSION)"';                                    \

--- a/python-localsrc.mk
+++ b/python-localsrc.mk
@@ -3,12 +3,12 @@ BUILD_METHOD := Registry
 include include/git-versioning.mk
 
 ifeq ($(strip $(VERSION)),)
-VERSION         := $(shell set -x; PYTHONPATH=chroma_agent python -c \
+VERSION         := $(shell set -x; PYTHONPATH=$(MODULE_SUBDIR) python -c \
 		     "import scm_version; print scm_version.VERSION")
 endif
 
 ifeq ($(strip $(PACKAGE_VERSION)),)
-PACKAGE_VERSION := $(shell set -x; PYTHONPATH=chroma_agent python -c \
+PACKAGE_VERSION := $(shell set -x; PYTHONPATH=$(MODULE_SUBDIR) python -c \
 		     "import scm_version; print scm_version.PACKAGE_VERSION")
 endif
 


### PR DESCRIPTION
Move MODULE_SUBDIR to git-versioning.mk.

Replace hard-coded "chroma_agent" with $(MODULE_SUBDIR).

Always rebuild the specfile from specfile.in.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>