### PR TITLE
python-localsrc modules should include common.mk also

### DIFF
--- a/python-localsrc.mk
+++ b/python-localsrc.mk
@@ -12,6 +12,7 @@ PACKAGE_VERSION := $(shell set -x; PYTHONPATH=$(MODULE_SUBDIR) python -c \
 		     "import scm_version; print scm_version.PACKAGE_VERSION")
 endif
 
+include include/common.mk
 include include/python-common.mk
 include include/rpm-common.mk
 include include/copr.mk


### PR DESCRIPTION
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>