### PR TITLE
Only remove the tarball source.

### DIFF
--- a/python-localsrc.mk
+++ b/python-localsrc.mk
@@ -17,9 +17,9 @@ include include/python-common.mk
 include include/rpm-common.mk
 include include/copr.mk
 
-# should always remove the sources if DIST_VERSION was set
+# should always remove the tarball sources if DIST_VERSION was set
 ifneq ($(DIST_VERSION),$(PACKAGE_VERSION))
-    $(shell rm -f $(RPM_SOURCES))
+    $(shell rm -f $(word 1,$(RPM_SOURCES)))
 endif
 
 %.egg-info/SOURCES.txt: install_build_deps-stamp


### PR DESCRIPTION
When building with a DIST_VERSION, and removing the $(RPM_SOURCES),
only remove the tarball (i.e. the first one).

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>