### PR TITLE
Set DRYRUN=false for Copr deploy

### DIFF
--- a/travis/copr-deploy.sh
+++ b/travis/copr-deploy.sh
@@ -16,7 +16,7 @@ build() {
     yum -y install rpm-build rpmdevtools copr-cli yum-utils git make python-setuptools
     echo 'travis_fold:end:yum'
     cd "${1:-/build}"
-    make iml_copr_build
+    make DRYRUN=false iml_copr_build
 
 }
 


### PR DESCRIPTION
Due to the change in 2bf93da we need to override the default of
only doing a dry run when doing a Copr deploy.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>