### PR TITLE
Allow a package to opt out of rpmlint

### DIFF
--- a/rpm-common.mk
+++ b/rpm-common.mk
@@ -1,4 +1,5 @@
-RPM_SPEC      ?= $(NAME).spec
+RPM_SPEC		?= $(NAME).spec
+RPMLINT_REQUIRED	?= true
 
 CLEAN += _topdir
 DISTCLEAN += dist
@@ -99,7 +100,13 @@ build_test: $(TARGET_SRPM)
 #include rpm_deps
 
 rpmlint: $(RPM_SPEC)
-	rpmlint $<
+	if ! rpmlint $<; then                                  \
+	    if ! $(RPMLINT_REQUIRED); then                     \
+	        echo "rpmlint not required, skipping failure"; \
+	    else                                               \
+	        exit 1;                                        \
+	    fi;                                                \
+	fi
 
 tags:
 	ctags -R .


### PR DESCRIPTION
Because we could be building other people's specfiles and
they may not be requiring rpmlint to pass.

Also, some specfiles are impossible to pass rpmlint with because
rpmlint does not support setting macros with.

But we still do always rpmlint, just for information.  We just
don't fail if the package has opted out.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>