### PR TITLE
Change default Copr build method to spec/srpm

### DIFF
--- a/copr.mk
+++ b/copr.mk
@@ -44,8 +44,8 @@ endif
 
 
 delete_copr_project:
-	if copr-cli list | grep $(NAME); then                     \
-	    $(ECHO) copr-cli $(COPR_CONFIG) delete $(NAME);               \
+	if copr-cli list | grep $(NAME); then               \
+	    $(ECHO) copr-cli $(COPR_CONFIG) delete $(NAME); \
 	fi
 
 create_copr_project: delete_copr_project
@@ -62,15 +62,15 @@ copr_build iml_copr_build: $(PREREQ)
 	#$(COPR_OWNER)/$(COPR_PROJECT)
 	$(ECHO) copr-cli $(COPR_CONFIG) build $(OWNER_PROJECT) $(filter-out \
 		create_copr_project,$^)
-else ifeq ($(BUILD_METHOD),Registry)
-copr_build iml_copr_build: $(PREREQ)
-	$(ECHO) copr-cli $(COPR_CONFIG) build $(OWNER_PROJECT) $(filter-out \
-		create_copr_project,$^)
-else
+else ifeq ($(BUILD_METHOD),SCM)
 copr_build iml_copr_build: $(PREREQ)
 	$(ECHO) copr-cli $(COPR_CONFIG) buildmock $(OWNER_PROJECT)       \
 		 --scm-type git                                  \
 		 --scm-url https://github.com/intel-hpdd/$(NAME)
+else
+copr_build iml_copr_build: $(PREREQ)
+	$(ECHO) copr-cli $(COPR_CONFIG) build $(OWNER_PROJECT) $(filter-out \
+		create_copr_project,$^)
 endif
 
 .PHONY: copr_build iml_copr_build

--- a/npm.mk
+++ b/npm.mk
@@ -4,7 +4,6 @@ CLEAN        += $(NAME)-$(PACKAGE_VERSION).tgz \
 include include/common.mk
 
 TARGET_RPMS = $(NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)$(RPM_DIST).noarch.rpm
-BUILD_METHOD := Registry
 
 include include/rpm-common.mk
 include include/copr.mk

--- a/python-localsrc.mk
+++ b/python-localsrc.mk
@@ -1,5 +1,3 @@
-BUILD_METHOD := Registry
-
 include include/git-versioning.mk
 
 ifeq ($(strip $(VERSION)),)


### PR DESCRIPTION
As it seems increasingly rare that we will use the Copr SCM
build method and increasinly clear that most modules will
use the spec/srpm upload method, change the default to uploading
a spec or srpm, as appropriate.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>