### PR TITLE
Build from SRPM on COPR for multiple sources

### DIFF
--- a/copr.mk
+++ b/copr.mk
@@ -32,7 +32,13 @@ else
   OWNER_PROJECT = $(COPR_OWNER)/$(COPR_PROJECT)
 endif
 
-ifeq ($(shell grep -q ^%patch $(RPM_SPEC); echo $${PIPESTATUS[0]}),0)
+ifeq ($(shell if grep -q ^%patch $(RPM_SPEC) ||   \
+                 [ "$$(grep ^Source $(RPM_SPEC) | \
+                       wc -l)" -gt 1 ]; then      \
+                  echo SRPM;                      \
+              else                                \
+                  echo SPEC;                      \
+             fi),SRPM)
   PREREQ += $(TARGET_SRPM)
 else
   ifeq ($(UNPUBLISHED),true)


### PR DESCRIPTION
If the specfile specifies multiple source, we need to send
the SRPM to COPR to build, not just the spec.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>