### PR TITLE
Get version and release from specfile

### DIFF
--- a/rpm.mk
+++ b/rpm.mk
@@ -1,5 +1,12 @@
+RPM_SPEC:= $(NAME).spec
+
+ifneq ($(REPO),)
 VERSION := $(shell repoquery --disablerepo=\* --enablerepo=$(REPO) -q --qf "%{version}" $(NAME) | sed -e 's/.el7//g')
 RELEASE := $(shell repoquery --disablerepo=\* --enablerepo=$(REPO) -q --qf "%{release}" $(NAME) | sed -e 's/.el7//g')
+else
+VERSION := $(shell rpmspec -q --srpm --qf "%{version}\n" $(RPM_SPEC))
+RELEASE := $(shell rpmspec -q --srpm --qf "%{release}\n" $(RPM_SPEC))
+endif
 
 PACKAGE_VERSION ?= $(VERSION)
 PACKAGE_RELEASE ?= $(RELEASE).01


### PR DESCRIPTION
If not using an RPM from a repo, assume there is a specfile that
is canonical and that we can get the desired version and release
from it.

A PACKAGE_VERSION and PACKAGE_RELEASE in the Makefile still over-
ride the specfile (but don't update the specfile) Version and
Release however.  This is not something you will likely want to
do.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>